### PR TITLE
[BUGFIX] set default host to 0.0.0.0 instead of localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ npm install
 # serve with hot reload at localhost:8080
 npm run dev
 
+# run dev setup inside docker container (assuming pwd is project root)
+docker run -p 8080:8080 -v $(pwd):/app -it --rm node bash
+cd app
+npm install
+npm run dev
+
 # build for production with minification
 npm run build
 

--- a/config/index.js
+++ b/config/index.js
@@ -13,7 +13,7 @@ module.exports = {
     proxyTable: {},
 
     // Various Dev Server settings
-    host: 'localhost', // can be overwritten by process.env.HOST
+    host: '0.0.0.0', // can be overwritten by process.env.HOST
     port: 8080, // can be overwritten by process.env.PORT, if port is in use, a free one will be determined
     autoOpenBrowser: false,
     errorOverlay: true,


### PR DESCRIPTION
Fixes #1 while still allowing connection from localhost since it binds to all available network interfaces.